### PR TITLE
Added detection of Geometry and Camera nodes

### DIFF
--- a/hooks/tk-nuke_scene_operations.py
+++ b/hooks/tk-nuke_scene_operations.py
@@ -16,7 +16,8 @@ class BreakdownSceneOperations(Hook):
     """
     Breakdown operations for Nuke.
 
-    This implementation handles detection of Nuke read nodes.
+    This implementation handles detection of Nuke read nodes,
+    geometry nodes and camera nodes.
     """
 
     def scan_scene(self):
@@ -51,9 +52,24 @@ class BreakdownSceneOperations(Hook):
             # %04d and %V rather than actual values.
             path = node.knob('file').value().replace("/", os.path.sep)
 
-            reads.append( {"node": node_name, "type": "read", "path": path})
+            reads.append( {"node": node_name, "type": "Read", "path": path})
+
+        # then the read geometry nodes    
+        for node in nuke.allNodes("ReadGeo2"):
+            node_name = node.name()
+            
+            path = node.knob('file').value().replace("/", os.path.sep)
+            reads.append( {"node": node_name, "type": "ReadGeo2", "path": path})
+        
+        # then the read camera nodes    
+        for node in nuke.allNodes("Camera2"):
+            node_name = node.name()
+            
+            path = node.knob('file').value().replace("/", os.path.sep)
+            reads.append( {"node": node_name, "type": "Camera2", "path": path})
 
         return reads
+
 
     def update(self, items):
         """
@@ -69,15 +85,18 @@ class BreakdownSceneOperations(Hook):
 
         engine = self.parent.engine
 
+        node_type_list = ["Read", "ReadGeo2", "Camera2"]
         for i in items:
             node_name = i["node"]
             node_type = i["type"]
             new_path = i["path"]
 
-            if node_type == "read":
+            if node_type in node_type_list :
                 engine.log_debug("Read node %s: Updating to version %s" % (node_name, new_path))
                 node = nuke.toNode(node_name)
                 # make sure slashes are handled correctly - always forward
                 new_path = new_path.replace(os.path.sep, "/")
                 node.knob("file").setValue(new_path)
+            else:
+                raise Exception("Unknown node type %s" % node_type)
 


### PR DESCRIPTION
By default the breakdown app only detects Read nodes. I added ReadGeo2 and Camera nodes as they are quite basic types that compers often need.
