### PR TITLE
thumbnail creation: pass QImage to QPixmap to avoid memory issues

### DIFF
--- a/python/tk_multi_breakdown/breakdown_list_item.py
+++ b/python/tk_multi_breakdown/breakdown_list_item.py
@@ -158,7 +158,7 @@ class BreakdownListItem(browser_widget.ListItem):
 
         # set thumbnail
         if data.get("thumbnail"):
-            self.ui.thumbnail.setPixmap(QtGui.QPixmap(data.get("thumbnail")))
+            self.ui.thumbnail.setPixmap(QtGui.QPixmap(QtGui.QImage(data.get("thumbnail"))))
 
         # set light - red or green
         if data["up_to_date"]:


### PR DESCRIPTION
Scene breakdown kept causing segmentation fault when a Maya scene had a large number (~170) references. Thumbnails seemed to be causing the issue.

From  [Stackoverflow](https://stackoverflow.com/questions/45846651/qpixmaps-in-pyqt-dont-get-cleaned-up-properly-when-made-directly-from-file-and), QPixmap methods that take a filename cache them, and the cache isn't cleared automatically, and there are issues with the mem limit on the cache.

We can either clear the cache after each thumbnail is displayed or pass something that is not a filename. Chose the latter approach as there are other pixmaps (red bullet,green bullet etc.) which it is probably useful to retain in the cache (and not clear each time).