### PR TITLE
SG-12365 Fixes missing import and updates use of hook.

### DIFF
--- a/app.py
+++ b/app.py
@@ -174,8 +174,7 @@ class MultiBreakdown(Application):
         :param fields: A complete set of fields for the template
         :returns: The highest version number found
         """
-        tk_multi_breakdown = self.import_module("tk_multi_breakdown")
-        return tk_multi_breakdown.compute_highest_version(template, fields)
+        return self.execute_hook("hook_get_version_number", template=template, curr_fields=fields)
         
         
     def update_item(self, node_type, node_name, template, fields):

--- a/python/tk_multi_breakdown/__init__.py
+++ b/python/tk_multi_breakdown/__init__.py
@@ -7,6 +7,7 @@
 # By accessing, using, copying or modifying this work you indicate your
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
+from breakdown import get_breakdown_items
 
 def show_dialog(app):
     # defer imports so that the app works gracefully in batch modes


### PR DESCRIPTION
Fixes an import that was mistakenly removed in the last version, so `app.analyze_scene` should work.

Updates `app.compute_highest_version` to use the hook rather than the old method.

To test:

1. Launch Maya, and start work on a Task on a Shot
2. Save a few files, and maybe reference some files via the loader
3. Then run this code:

```python
import sgtk
engine = sgtk.platform.current_engine()

breakdown = engine.commands["Scene Breakdown..."]["properties"]["app"]

# Test the analyze_scene this would have errored with "no attribute 'get_breakdown_items'"
# Should return a list of referenced in scenes, or an empty list if none were loaded.
print breakdown.analyze_scene()

template = engine.sgtk.templates["maya_shot_work"]
fields = engine.context.as_template_fields(template)
# If you have saved a scene or two it should return the highest current version number
print breakdown.compute_highest_version(template,fields)
```