### PR TITLE
Replace the item label entity type with entity type display name

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -49,3 +49,4 @@ supported_engines:
 # the frameworks required to run this app
 frameworks:
     - {"name": "tk-framework-widget", "version": "v0.2.x"}
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.2.1"}

--- a/python/tk_multi_breakdown/scene_browser.py
+++ b/python/tk_multi_breakdown/scene_browser.py
@@ -119,7 +119,10 @@ class SceneBrowserWidget(browser_widget.BrowserWidget):
                     # see if this publish is associated with an entity
                     linked_entity = sg_data.get("entity")
                     if linked_entity:
-                        details.append( self._make_row(linked_entity["type"], linked_entity["name"]) )
+                        display_name = tank.util.get_entity_type_display_name(tank.platform.current_engine().tank,
+                                                                              linked_entity["type"])
+    
+                        details.append(self._make_row(display_name, linked_entity["name"]))
 
                     # does it have a tank type ?
                     if sg_data.get(published_file_type_field):

--- a/python/tk_multi_breakdown/scene_browser.py
+++ b/python/tk_multi_breakdown/scene_browser.py
@@ -20,6 +20,7 @@ from tank.platform.qt import QtCore, QtGui
 from . import breakdown
 
 browser_widget = tank.platform.import_framework("tk-framework-widget", "browser_widget")
+shotgun_globals = tank.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
 
 from .breakdown_list_item import BreakdownListItem
 
@@ -119,8 +120,7 @@ class SceneBrowserWidget(browser_widget.BrowserWidget):
                     # see if this publish is associated with an entity
                     linked_entity = sg_data.get("entity")
                     if linked_entity:
-                        display_name = tank.util.get_entity_type_display_name(tank.platform.current_engine().tank,
-                                                                              linked_entity["type"])
+                        display_name = shotgun_globals.get_type_display_name(linked_entity["type"])
     
                         details.append(self._make_row(display_name, linked_entity["name"]))
 


### PR DESCRIPTION
Currently the details widget is using the entity type and a friendly value for this could be the display_name.

![image](https://user-images.githubusercontent.com/2762494/71253376-b78ca080-22f5-11ea-9602-67079bed2e00.png)
