### PR TITLE
SG-4617 many item crash

### DIFF
--- a/python/tk_multi_breakdown/breakdown_list_item.py
+++ b/python/tk_multi_breakdown/breakdown_list_item.py
@@ -59,9 +59,7 @@ class BreakdownListItem(browser_widget.ListItem):
         else:
             return self._is_latest == False
 
-    def _load_started(
-        self, template, fields, show_red, show_green, entity_dict=None
-    ):
+    def _load_started(self, template, fields, show_red, show_green, entity_dict=None):
         """
         Figure out if this is a red or a green one. Also get thumb if possible
         """
@@ -86,9 +84,7 @@ class BreakdownListItem(browser_widget.ListItem):
         status for this item. This is run in a worker thread.
         """
         # set up the payload
-        output = {
-            "id": data["id"]
-        }
+        output = {"id": data["id"]}
 
         # First, calculate the thumbnail
         # see if we can download a thumbnail

--- a/python/tk_multi_breakdown/breakdown_list_item.py
+++ b/python/tk_multi_breakdown/breakdown_list_item.py
@@ -86,9 +86,6 @@ class BreakdownListItem(browser_widget.ListItem):
         self._browser._item_work_failed.connect(self._on_worker_failure)
         self._worker_uid = self._worker.queue_work(self._calculate_status, {})
 
-    def _set_task_uid(self, uid):
-        self._task_uid = uid
-
     def _calculate_status(self, data):
         """
         The computational payload that downloads thumbnails and figures out the

--- a/python/tk_multi_breakdown/scene_browser.py
+++ b/python/tk_multi_breakdown/scene_browser.py
@@ -180,7 +180,7 @@ class SceneBrowserWidget(browser_widget.BrowserWidget):
                 self._worker.queue_work(i._calculate_status, {"id": id(i)})
 
     def _on_item_load_complete(self, uid, data):
-        #TODO: If we go with this option, put the ids in a dict for faster lookup?
+        # TODO: If we go with this option, put the ids in a dict for faster lookup?
         match = [x for x in self._dynamic_widgets if id(x) == data.get("id")]
         if match:
             match[0]._load_succeeded(data)

--- a/python/tk_multi_breakdown/scene_browser.py
+++ b/python/tk_multi_breakdown/scene_browser.py
@@ -49,7 +49,6 @@ class SceneBrowserWidget(browser_widget.BrowserWidget):
             self.set_message("No versioned data in your scene!")
             return
 
-        self._worker_uids = {}
         ################################################################################
         # PASS 1 - grouping
         # group these items into various buckets first based on type, and asset type


### PR DESCRIPTION
**This PR is not complete. It's meant to be a starting point for a discussion.** 

Breakdown app crashes when there are lots of items for it to process (I'm testing with 200). I have not been able to find out why this happens, but I do know where it happens. Each item queues its own background work (to get the thumbnail and status) on the main browser's background worker thread. They all connect to the "work_completed" signal on the worker and process the results that belong to them. 

For some reason, when the number of BreakdownListItem widgets gets large, the call to emit "work_completed" in the worker causes a segmentation fault. 

I've tried the worker thread in a simple scenario, not attaching it to widget methods but just regular methods and it can handle way more than 200 connections with no issue. So I think this has to do with QWidgets specifically. But I couldn't come up with a way to get deep enough to figure out where the crash is happening. I was hoping I could call the connected methods directly (instead of broadcasting an emit) to see if I can figure out what is broken. But it's not possible to get the list of connections from Qt as far as I can tell. 

This workaround makes sure we never have that many connections and it seems to solve the problem. I'm not a fan of working around something I don't understand, but if there's no better way to debug the seg fault, at least we have a solution. 

The way this solution works is to move the connection up from the BreakdownListItem to its parent SceneBrowserWidget. The emit signal from the worker is notifying the browser that one of its items need updating instead of notifying the item directly. The SceneBrowser is then responsible for calling the necessary method on the BreakdownListItem. 