### PR TITLE
SG-20497 Fixes a bug with finding multiple instances of the same reference.

### DIFF
--- a/hooks/tk-maya_scene_operations.py
+++ b/hooks/tk-maya_scene_operations.py
@@ -49,7 +49,9 @@ class BreakdownSceneOperations(Hook):
 
             # get the path and make it platform dependent
             # (maya uses C:/style/paths)
-            maya_path = ref.replace("/", os.path.sep)
+            maya_path = cmds.referenceQuery(
+                ref, filename=1, withoutCopyNumber=1
+            ).replace("/", os.path.sep)
             refs.append({"node": node_name, "type": "reference", "path": maya_path})
 
         # now look at file texture nodes

--- a/hooks/tk-maya_scene_operations.py
+++ b/hooks/tk-maya_scene_operations.py
@@ -44,13 +44,13 @@ class BreakdownSceneOperations(Hook):
         refs = []
 
         # first let's look at maya references
-        for ref in cmds.file(q=1, reference=1):
-            node_name = cmds.referenceQuery(ref, referenceNode=1)
+        for ref in cmds.file(q=True, reference=True):
+            node_name = cmds.referenceQuery(ref, referenceNode=True)
 
             # get the path and make it platform dependent
             # (maya uses C:/style/paths)
             maya_path = cmds.referenceQuery(
-                ref, filename=1, withoutCopyNumber=1
+                ref, filename=True, withoutCopyNumber=True
             ).replace("/", os.path.sep)
             refs.append({"node": node_name, "type": "reference", "path": maya_path})
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,17 +16,10 @@ Users
 ```
 
 ## Running the tests
-Navigate to the `tests` folder in the tk-core repo, and execute the test runner. Point it
-at the location of this app:
+Navigate to the `tk-multi-breakdown` folder/repo, and execute pytest.
 
-```
-cd /path/to/tk-core/tests
-./run_tests.sh --test-root=/path/to/tk-multi-breakdown/tests
-```
-
-alternatively, to run it directly:
 
 ```
 cd /path/to/tk-multi-breakdown
-/path/to/tk-core/tests/run_tests.sh --test-root=./tests
+pytest
 ```

--- a/tests/fixtures/config/hooks/scene_operations.py
+++ b/tests/fixtures/config/hooks/scene_operations.py
@@ -44,13 +44,14 @@ class BreakdownSceneOperations(Hook):
         nodes.append(
             {"node": "outside_template_system", "type": "TestNode", "path": "/foo/bar"}
         )
-        nodes.append(
-            {
-                "node": "maya_publish",
-                "type": "TestNode",
-                "path": os.environ["TEST_PATH_1"],
-            }
-        )
+        for env_var in ["TEST_PATH_1", "TEST_PATH_1_DUPE"]:
+            nodes.append(
+                {
+                    "node": "maya_publish",
+                    "type": "TestNode",
+                    "path": os.environ[env_var],
+                }
+            )
 
         return nodes
 

--- a/tests/test_breakdown.py
+++ b/tests/test_breakdown.py
@@ -154,6 +154,9 @@ class TestApi(TestApplication):
         Tests the analyze_scene method
         """
         scene_data = self.app.analyze_scene()
+
+        # There should be two identical items collected,
+        # because we provided two identical paths in the setup.
         self.assertEqual(len(scene_data), 2)
 
         for item in scene_data:

--- a/tests/test_breakdown.py
+++ b/tests/test_breakdown.py
@@ -145,6 +145,8 @@ class TestApi(TestApplication):
         # this will be read by our hook so push
         # it out into env vars...
         os.environ["TEST_PATH_1"] = self.test_path_1
+        # Add the same path twice ensure that it collects both
+        os.environ["TEST_PATH_1_DUPE"] = self.test_path_1
         os.environ["TEST_PATH_2"] = self.test_path_2
 
     def test_analyze_scene(self):
@@ -152,25 +154,25 @@ class TestApi(TestApplication):
         Tests the analyze_scene method
         """
         scene_data = self.app.analyze_scene()
-        self.assertEqual(len(scene_data), 1)
+        self.assertEqual(len(scene_data), 2)
 
-        item = scene_data[0]
-        self.assertEqual(
-            item["fields"],
-            {
-                "Shot": "shot_code",
-                "name": "foo",
-                "Sequence": "seq_code",
-                "Step": "step_short_name",
-                "version": 3,
-                "maya_extension": "ma",
-                "eye": "%V",
-            },
-        )
-        self.assertEqual(item["node_name"], "maya_publish")
-        self.assertEqual(item["node_type"], "TestNode")
-        self.assertEqual(item["template"], self.tk.templates["maya_shot_publish"])
-        self.assertEqual(item["sg_data"], None)
+        for item in scene_data:
+            self.assertEqual(
+                item["fields"],
+                {
+                    "Shot": "shot_code",
+                    "name": "foo",
+                    "Sequence": "seq_code",
+                    "Step": "step_short_name",
+                    "version": 3,
+                    "maya_extension": "ma",
+                    "eye": "%V",
+                },
+            )
+            self.assertEqual(item["node_name"], "maya_publish")
+            self.assertEqual(item["node_type"], "TestNode")
+            self.assertEqual(item["template"], self.tk.templates["maya_shot_publish"])
+            self.assertEqual(item["sg_data"], None)
 
     def test_compute_highest_version(self):
         """


### PR DESCRIPTION
When you have multiple instances of a reference in your scene, Maya adds a {x} to the end of the given file path where x is a number representing the number of the copy.
This fix now asks for the path with out the copy number.

This code and output illustrates the issue if multiple instances of a reference were present in the scene

```python
print("broken")
for ref in cmds.file(q=1, reference=1):
    print(ref)
    
print("fixed")
for ref in cmds.file(q=1, reference=1):
    file_name = cmds.referenceQuery(ref, filename=True, withoutCopyNumber=1)
    print(file_name)
```
```text
>>
broken
/projects/garden-show/assets/Environment/rock-rose/MDL/publish/maya/scene.v001.ma
/projects/garden-show/assets/Environment/rock-rose/MDL/publish/maya/scene.v001.ma{1}
/projects/garden-show/assets/Environment/rock-rose/MDL/publish/maya/scene.v001.ma{2}
fixed
/projects/garden-show/assets/Environment/rock-rose/MDL/publish/maya/scene.v001.ma
/projects/garden-show/assets/Environment/rock-rose/MDL/publish/maya/scene.v001.ma
/projects/garden-show/assets/Environment/rock-rose/MDL/publish/maya/scene.v001.ma

```