### PR TITLE
SG-20925 Formalize the deprecation of python 2.6 support in toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python 2.6 2.7 3.7](https://img.shields.io/badge/python-2.6%20%7C%202.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Apps/tk-multi-breakdown?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=52&branchName=master)
 [![codecov](https://codecov.io/gh/shotgunsoftware/tk-multi-breakdown/branch/master/graph/badge.svg)](https://codecov.io/gh/shotgunsoftware/tk-multi-breakdown)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)


### PR DESCRIPTION
This PR includes the actions to remove Python 2.6 support in toolkit:
        - Remove python 2.6 badges
        - Update setup.py to drop support for 2.6
        - Update the documentation and the developer.shotgunsoftware.com doc site